### PR TITLE
Remove old permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,13 +23,6 @@
             ]
         }
     ],
-    "permissions": [
-        "activeTab",
-        "storage"
-    ],
-    "host_permissions": [
-        "https://games.roblox.com/*"
-    ],
     "web_accessible_resources": [
         {
             "resources": [


### PR DESCRIPTION
Permissions `activeTab`, `storage`, and host_permission `games.roblox.com` are not in use since v2.